### PR TITLE
More debug code for `-p` option

### DIFF
--- a/smc-command/smc.c
+++ b/smc-command/smc.c
@@ -714,6 +714,7 @@ int main(int argc, char *argv[])
                 {
                   float fval;
                   fval = strtof(optarg, NULL);
+                  //printf("Input: %f\n", fval);
 
                   val.dataSize = 4;
                   memcpy(val.bytes, &fval, sizeof(fval));
@@ -796,6 +797,8 @@ int main(int argc, char *argv[])
                 result = SMCWriteKey(val);
                 if (result != kIOReturnSuccess)
                     printf("Error: SMCWriteKey() = %08x\n", result);
+                //else
+                    //printf("SMCWriteKey() succeeded\n");
             }
             else
             {

--- a/smc-command/smc.c
+++ b/smc-command/smc.c
@@ -718,6 +718,11 @@ int main(int argc, char *argv[])
                   val.dataSize = 4;
                   memcpy(val.bytes, &fval, sizeof(fval));
                   memcpy(val.dataType, DATATYPE_FLT, sizeof(val.dataType));
+
+                  // Debugging code
+                  printf("Writing: ");
+                  printVal(val);
+                  printf("\n");
                 }
                 break;
             case 'w':


### PR DESCRIPTION
Basically, just pretty-print again the parsed `-p` value. The point was to test my encoding code against the existing decoding code.